### PR TITLE
Change light theme code text color to something light (and readable)

### DIFF
--- a/assets/css/_main.css
+++ b/assets/css/_main.css
@@ -153,6 +153,7 @@ pre:has(code) {
   overflow-x: auto;
   padding: .8rem;
   border-radius: .3rem;
+  color: var(--code-text-color);
   background-color: var(--code-background-color) !important;
 }
 


### PR DESCRIPTION
This "fix" may be the result of something else misconfigured in the theme on my part, but when using "light" mode, block code text was dark on a dark background and unreadable.

This tweak makes hugo render code block text light on a dark background, and thus readable in light mode.

I forked your repo so I could make the change and sync across my websites easily, but if it's something you want then I'd be happy to push the change upstream to you.