### PR TITLE
Fix handling of color scheme

### DIFF
--- a/assets/js/_theme.js
+++ b/assets/js/_theme.js
@@ -6,7 +6,7 @@
       const cachedTheme = localStorage.getItem("color-scheme");
       if (cachedTheme) {
         return cachedTheme;
-      } else if (theme !== "dark" || theme !== "light") {
+      } else if (theme !== "dark" && theme !== "light") {
         let preferDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
         return preferDark ? "dark" : "light";
       } else {
@@ -16,7 +16,7 @@
 
     const toggle = (state) => state === "light" ? "dark" : "light";
     const initTheme = (state) => {
-      document.documentElement.setAttribute("color-scheme", toggle(state));
+      document.documentElement.setAttribute("color-scheme", state);
     };
 
     const toggleTheme = () => {


### PR DESCRIPTION
Found a few issues with the handling of colour schemes in `asserts/js/_theme.js`!

1. Removed a redundant call to `toggle()` in `initTheme()`.
2. Replaced the condition `theme !== "dark" || theme !== "light"` with `theme !== "dark" && theme !== "light"` in `getCachedTheme()`.
