### PR TITLE
add support for content in single pages

### DIFF
--- a/layouts/partials/components/content.html
+++ b/layouts/partials/components/content.html
@@ -1,0 +1,19 @@
+{{- with .section }}
+  {{- $section := . -}}
+  {{- $data := index site.Data.rtwt.content.side $section -}}
+  {{- range $data -}}
+    <div class="side-content">
+      <h3>{{- .title -}}</h3>
+      {{- if .imagePath -}}
+        {{- if .imageHref -}}
+          <a href="{{- .imageHref -}}" target="_blank" rel="noopener noreferrer">
+            <img class="side-content-image" src="{{- .imagePath -}}" width="{{- default "80%" .imageWidth -}}" />
+          </a>
+        {{- else -}}
+          <img class="side-content-image" src="{{- .imagePath -}}" width="{{- default "80%" .imageWidth -}}" />
+        {{- end -}}
+      {{- end -}}
+      <p>{{- markdownify .content -}}</p>
+    </div>
+  {{- end -}}
+{{- end }}

--- a/layouts/partials/side/home.html
+++ b/layouts/partials/side/home.html
@@ -1,20 +1,6 @@
 {{- partial "search_bar.html" -}}
 
-{{- range site.Data.rtwt.content.side.home -}}
-  <div class="side-content">
-    <h3>{{- .title -}}</h3>
-    {{- if .imagePath -}}
-      {{- if .imageHref -}}
-        <a href="{{- .imageHref -}}" target="_blank" rel="noopener noreferrer">
-          <img class="side-content-image" src="{{- .imagePath -}}" width="{{- default "80%" .imageWidth -}}" />
-        </a>
-      {{- else -}}
-        <img class="side-content-image" src="{{- .imagePath -}}" width="{{- default "80%" .imageWidth -}}" />
-      {{- end -}}
-    {{- end -}}
-    <p>{{- markdownify .content -}}</p>
-  </div>
-{{- end -}}
+{{ partial "components/content.html" (dict "section" "home") }}
 
 {{- range $filter := site.Params.rtwt.side.home.taxonomies -}}
   {{- with (index site.Taxonomies $filter) -}}

--- a/layouts/partials/side/single.html
+++ b/layouts/partials/side/single.html
@@ -1,4 +1,5 @@
 {{- $baseURL := .Site.BaseURL -}}
+{{ partial "components/content.html" (dict "section" "single") }}
 {{- if site.Params.rtwt.side.single.showDetails -}}
   <div class="side-details">
     <span>{{- .WordCount }} {{ i18n "details_words" -}}</span>


### PR DESCRIPTION
Extracted side content rendering logic into a new partial 'components/content.html'.

Updated 'home.html' and 'single.html' to use it. This allows the usage of content in single pages.

```yml
side:
  home:
    - title: 'Media Support'
      content: 'Side content can have images!'
      imagePath: 'images/hugo.svg'
      imageHref: 'https://gohugo.io'
      imageWidth: '100%'
  single:
  - title: 'Media Support 2'
    content: 'Side content can have images!'
    imagePath: 'images/hugo.svg'
    imageHref: 'https://gohugo.io'
    imageWidth: '100%'


`
``
