### PR TITLE
Correct typo in font-weight-main

### DIFF
--- a/assets/css/root.css
+++ b/assets/css/root.css
@@ -2,7 +2,7 @@
 
 :root {
   --font-family-main: "Bricolage Grotesque", sans-serif;
-  --font-weigth-main: 500;
+  --font-weight-main: 500;
   --font-family-content: "Bricolage Grotesque", serif;
   --font-weight-content: 500;
   --font-family-summary: "Bricolage Grotesque", serif;


### PR DESCRIPTION
Correct typo from --font-weigth-main to --font-weight-main