### PR TITLE
Fix incorrect param path for countRecent in micro_list.html

### DIFF
--- a/layouts/partials/home/micro_list.html
+++ b/layouts/partials/home/micro_list.html
@@ -3,7 +3,7 @@
 
 <h2>{{- $title -}}</h2>
 <div class="flat-list">
-  {{- range first (default 5 site.Params.rtw_theme.params.home.countRecent) $items -}}
+  {{- range first (default 5 site.Params.rtwt.home.countRecent) $items -}}
     <div class="flat-list-item">
       <div>
         <a href="{{- .RelPermalink -}}">{{- .LinkTitle -}}</a>


### PR DESCRIPTION
`micro_list.html` reads `site.Params.rtw_theme.params.home.countRecent`, but the theme's own config and docs use `site.Params.rtwt.home.countRecent`. Since the former never resolves, the `default 5` fallback always applies, so setting `countRecent` in config has no effect. This corrects the path to match the actual namespace.